### PR TITLE
Support for custom top level metadata

### DIFF
--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -40,6 +40,10 @@ class PagerfantaHandler extends AbstractPaginationHandler
 
         $items = $object->getCurrentPageResults();
 
+        if ($items instanceof \ArrayIterator) {
+            $items = $items->getArrayCopy();
+        }
+
         return new PaginatedRepresentation(
             $items,
             $object->getCurrentPage(),


### PR DESCRIPTION
This PR fixes issue #14 and makes it possible to include your own metadata. It works by explicitly defining the data key and the meta key in the serialize method (or the views data if your using FOSRestBundle).

Use it like this:

``` php
$this->get('serializer')->serialize(array(
    'meta' => array(
        'meta_key' => 'meta_value'
    ),
    'data' => $data
), 'json');
```

Note that when you have a paginated response, which means your `$data` is for example a `Pagerfanta` instance. If you pass in the `meta` key, then it will override the default metadata that this bundle generates.
