### PR TITLE
return null if class is abstract

### DIFF
--- a/Configuration/Metadata/Driver/AnnotationDriver.php
+++ b/Configuration/Metadata/Driver/AnnotationDriver.php
@@ -44,7 +44,11 @@ class AnnotationDriver implements DriverInterface
     public function loadMetadataForClass(\ReflectionClass $class)
     {
         $annotations = $this->reader->getClassAnnotations($class);
-
+        
+        if ($class->isAbstract()) {
+            return null;
+        }
+        
         if (0 === count($annotations)) {
             return null;
         }


### PR DESCRIPTION
Prevents abstract base classes from having their JsonApi annotations loaded when serializing a class that inherits from the base class.  Allowing them to be loaded causes JMS serializer to load the base class annotations first and never load the child class annotations at all.  Fixes issue noted in #16 , however a base class that is not abstract will still get the wrong annotations when serializing the child object.
