### PR TITLE
Dynamically resolve resource type, more accurate resource type

### DIFF
--- a/Configuration/Metadata/Driver/AnnotationDriver.php
+++ b/Configuration/Metadata/Driver/AnnotationDriver.php
@@ -54,10 +54,6 @@ class AnnotationDriver implements DriverInterface
 
         foreach ($annotations as $annotation) {
             if ($annotation instanceof Annotation\Resource) {
-                // auto transform type from class name
-                if (!$annotation->type) {
-                    $annotation->type = StringUtil::dasherize($class->getShortName());
-                }
                 $classMetadata->setResource(new Resource($annotation->type, $annotation->showLinkSelf));
             }
         }

--- a/Configuration/Metadata/Driver/YamlDriver.php
+++ b/Configuration/Metadata/Driver/YamlDriver.php
@@ -82,7 +82,7 @@ class YamlDriver extends AbstractFileDriver
             $resource = $config['resource'];
 
             return new Resource(
-                isset($resource['type']) ? $resource['type'] : StringUtil::dasherize($class->getShortName()),
+                $resource['type'],
                 isset($resource['showLinkSelf']) ? $resource['showLinkSelf'] : null
             );
         }

--- a/Configuration/Resource.php
+++ b/Configuration/Resource.php
@@ -34,10 +34,6 @@ class Resource
      */
     public function __construct($type, $showLinkSelf = null)
     {
-        if (null === $type) {
-            throw new \RuntimeException('A JSON-API resource must have a type defined and cannot be "null".');
-        }
-
         $this->type = $type;
 
         if (null !== $showLinkSelf) {
@@ -52,7 +48,7 @@ class Resource
      */
     public function getType($object)
     {
-        if ('auto' === $this->type) {
+        if (!$this->type) {
             $reflectionClass = new \ReflectionClass($object);
             return StringUtil::dasherize($reflectionClass->getShortName());
         }

--- a/Configuration/Resource.php
+++ b/Configuration/Resource.php
@@ -11,6 +11,8 @@
 
 namespace Mango\Bundle\JsonApiBundle\Configuration;
 
+use Mango\Bundle\JsonApiBundle\Util\StringUtil;
+
 /**
  * @author Steffen Brem <steffenbrem@gmail.com>
  */
@@ -44,10 +46,17 @@ class Resource
     }
 
     /**
+     * @param null|object $object
+     *
      * @return string
      */
-    public function getType()
+    public function getType($object)
     {
+        if ('auto' === $this->type) {
+            $reflectionClass = new \ReflectionClass($object);
+            return StringUtil::dasherize($reflectionClass->getShortName());
+        }
+
         return $this->type;
     }
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
 ```
 | Property      | Default | Required  | Content   | Info  |
 | ---           | ---     | ---       | ---       | ---   |
-| type          | ~       | No        | string    | If not present, it will use the dasherized classname as it's type |
+| type          | ~       | No        | string    | If left default, it will use the dasherized classname as it's type. |
 | showLinkSelf  | true    | No        | boolean   | Add `self` link to the resource |
+
+> TIP: You can use the type `auto` if you want to determine its type automatically at runtime. This can be useful if you only define a mapping for an abstract class.
 
 ### @Id (optional, it defaults to `id`)
 This will define the property that will be used as the `id` of a resource. It needs to be unique for every resource of the same type.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
 ```
 | Property      | Default | Required  | Content   | Info  |
 | ---           | ---     | ---       | ---       | ---   |
-| type          | ~       | No        | string    | If left default, it will use the dasherized classname as it's type. |
+| type          | ~       | No        | string    | If left default, it will resolve its type dynamically based on the short class name. |
 | showLinkSelf  | true    | No        | boolean   | Add `self` link to the resource |
-
-> TIP: You can use the type `auto` if you want to determine its type automatically at runtime. This can be useful if you only define a mapping for an abstract class.
 
 ### @Id (optional, it defaults to `id`)
 This will define the property that will be used as the `id` of a resource. It needs to be unique for every resource of the same type.


### PR DESCRIPTION
* Added support for `auto` resource type. This will be resolved in runtime to the objects type.

Maybe even drop the use of `~` and use that symbol for dynamic type resolving.