### PR TITLE
Quick fix: Change detection of resources

### DIFF
--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -114,11 +114,11 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
      */
     protected function validateJsonApiDocument($data)
     {
-        if (is_array($data) && count($data) > 0 && !$this->hasResource($data)) {
-            return false;
+        if (is_array($data) && count($data) > 0 && $this->hasResource($data)) {
+            return true;
         }
 
-        return true;
+        return $this->isResource($data);
     }
 
     /**

--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -114,7 +114,7 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
      */
     protected function validateJsonApiDocument($data)
     {
-        if (is_array($data) && count($data) > 0 && $this->hasResource($data)) {
+        if ((is_array($data) || $data instanceof \Traversable) && count($data) > 0 && $this->hasResource($data)) {
             return true;
         }
 


### PR DESCRIPTION
The previous approach was way too less defensive as  `validateJsonApiDocument` returned `true` by default for any object as only arrays with a length AND NOT containing a resource were evaluated `false`. Actually even the docblock points out a different behavior.